### PR TITLE
[Execution] Add ability to disable Git integration

### DIFF
--- a/errors/errors.yml
+++ b/errors/errors.yml
@@ -123,6 +123,14 @@
   name: ConductorAbort
   message: "Conductor's execution has been aborted by the user."
 
+3005:
+  name: ConfigParseError
+  message: "Conductor failed to parse cond_config.toml."
+
+3006:
+  name: ConfigInvalidValue
+  message: "Encountered an invalid value for '{config_key}' in cond_config.toml."
+
 
 # Archive and restore errors (error code 4xxx)
 4001:

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,9 @@ ENTRY_POINTS = {
     ],
 }
 
-INSTALL_REQUIRES = []
+INSTALL_REQUIRES = [
+    "tomli",
+]
 
 DEV_REQUIRES = [
     "black",

--- a/src/conductor/config_file.py
+++ b/src/conductor/config_file.py
@@ -1,0 +1,35 @@
+import tomli
+import pathlib
+
+from typing import Any, Dict
+from conductor.errors import ConfigParseError, ConfigInvalidValue
+
+
+class ConfigFile:
+    def __init__(self, raw_config: Dict[str, Any]):
+        self._raw_config = raw_config
+
+    @classmethod
+    def load_from_file(cls, filepath: pathlib.Path) -> "ConfigFile":
+        try:
+            with open(filepath, "rb") as file:
+                return cls(raw_config=tomli.load(file))
+        except tomli.TOMLDecodeError as ex:
+            raise ConfigParseError().add_extra_context(str(ex))
+
+    @property
+    def disable_git(self) -> bool:
+        # Disables Conductor's git integration.
+        # Default: False
+        if _DISABLE_GIT_KEY not in self._raw_config:
+            return False
+        value = self._raw_config[_DISABLE_GIT_KEY]
+        if type(value) is not bool:
+            raise ConfigInvalidValue(config_key=_DISABLE_GIT_KEY).add_extra_context(
+                "The value must be a boolean."
+            )
+        return value
+
+
+# Config keys (global)
+_DISABLE_GIT_KEY = "disable_git"

--- a/src/conductor/context.py
+++ b/src/conductor/context.py
@@ -3,6 +3,7 @@ import pathlib
 from typing import Optional
 
 from conductor.config import CONFIG_FILE_NAME, OUTPUT_DIR, VERSION_INDEX_NAME
+from conductor.config_file import ConfigFile
 from conductor.errors import MissingProjectRoot, OutputDirTaken
 from conductor.execution.version_index import VersionIndex
 from conductor.parsing.task_index import TaskIndex
@@ -22,9 +23,15 @@ class Context:
         self._output_path = project_root / OUTPUT_DIR
         self._ensure_output_dir_exists()
 
+        self._config_file = ConfigFile.load_from_file(
+            pathlib.Path(self._project_root, CONFIG_FILE_NAME)
+        )
+
         self._git = Git(self._project_root)
-        self._uses_git = self._git.is_used()
-        self._curr_commit = self._git.current_commit() if self._uses_git else None
+        self._uses_git_fetched = False
+        self._uses_git = False
+        self._curr_commit_fetched = False
+        self._curr_commit: Optional[Git.Commit] = None
 
         self._version_index = VersionIndex.create_or_load(
             pathlib.Path(self.output_path, VERSION_INDEX_NAME)
@@ -68,10 +75,16 @@ class Context:
 
     @property
     def uses_git(self) -> bool:
+        if not self._uses_git_fetched:
+            self._uses_git = (not self._config_file.disable_git) and self._git.is_used()
+            self._uses_git_fetched = True
         return self._uses_git
 
     @property
     def current_commit(self) -> Optional[Git.Commit]:
+        if not self._curr_commit_fetched:
+            self._curr_commit = self._git.current_commit() if self.uses_git else None
+            self._curr_commit_fetched = True
         return self._curr_commit
 
     @property

--- a/src/conductor/errors/generated.py
+++ b/src/conductor/errors/generated.py
@@ -347,6 +347,32 @@ class ConductorAbort(ConductorError):
         )
 
 
+class ConfigParseError(ConductorError):
+    error_code = 3005
+
+    def __init__(self, **kwargs):
+        super().__init__()
+
+    
+    def _message(self):
+        return "Conductor failed to parse cond_config.toml.".format(
+
+        )
+
+
+class ConfigInvalidValue(ConductorError):
+    error_code = 3006
+
+    def __init__(self, **kwargs):
+        super().__init__()
+        self.config_key = kwargs["config_key"]
+    
+    def _message(self):
+        return "Encountered an invalid value for '{config_key}' in the configuration.".format(
+            config_key=self.config_key,
+        )
+
+
 class OutputFileExists(ConductorError):
     error_code = 4001
 
@@ -451,6 +477,8 @@ __all__ = [
     "TaskFailed",
     "OutputDirTaken",
     "ConductorAbort",
+    "ConfigParseError",
+    "ConfigInvalidValue",
     "OutputFileExists",
     "OutputPathDoesNotExist",
     "NoTaskOutputsToArchive",

--- a/tests/config_file_test.py
+++ b/tests/config_file_test.py
@@ -1,0 +1,35 @@
+import pathlib
+import pytest
+
+from conductor.config_file import ConfigFile
+from conductor.errors import ConfigParseError, ConfigInvalidValue
+
+
+def test_parse_error(tmp_path: pathlib.Path):
+    test_file = tmp_path / "config.toml"
+    with open(test_file, "w", encoding="UTF-8") as file:
+        # Invalid TOML
+        file.write("abcdefg!@#$%12345\n")
+
+    with pytest.raises(ConfigParseError):
+        ConfigFile.load_from_file(test_file)
+
+
+def test_invalid_disable_git(tmp_path: pathlib.Path):
+    test_file = tmp_path / "config.toml"
+    with open(test_file, "w", encoding="UTF-8") as file:
+        # Invalid `disable_git` value (should be a boolean)
+        file.write("disable_git = 123\n")
+
+    config = ConfigFile.load_from_file(test_file)
+    with pytest.raises(ConfigInvalidValue):
+        _ = config.disable_git
+
+
+def test_valid_disable_git(tmp_path: pathlib.Path):
+    test_file = tmp_path / "config.toml"
+    with open(test_file, "w", encoding="UTF-8") as file:
+        file.write("disable_git = true\n")
+
+    config = ConfigFile.load_from_file(test_file)
+    assert config.disable_git == True


### PR DESCRIPTION
This PR also adds Conductor's first dependency (`tomli`). Add `disable_git = true` to `cond_config.toml` to disable Conductor's git integration. Conductor's git integration is already gracefully disabled when the project does not use git. This configuration option allows users to disable the integration when the project _does_ use git.