### PR TITLE
[Execution] Add ability to execute tasks in parallel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,9 +44,9 @@ jobs:
     - name: Type Check (mypy)
       run: ./tools/check-code.sh types
       if: success() || failure()
-    
+
     - name: Run Tests (pytest)
-      run: pytest --quiet
+      run: pytest
       if: success() || failure()
 
     - name: Build Wheels

--- a/errors/errors.yml
+++ b/errors/errors.yml
@@ -168,3 +168,13 @@
   message: >-
     Conductor is not supported on your system. Conductor only supports Linux and
     macOS.
+
+5004:
+  name: InvalidJobsCount
+  message: "The maximum number of parallel jobs must be at least 1."
+
+5005:
+  name: CannotSelectJobCount
+  message: >-
+    Conductor could not automatically set the maximum number of parallel jobs.
+    Please explicitly specify a number using the --jobs flag.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+# Configuration option for `pytest-timeout`
+# An individual unit test cannot take longer than 30 seconds.
+timeout = 30

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ DEV_REQUIRES = [
     "pep517",
     "pylint",
     "pytest",
+    "pytest-timeout",
     "pyyaml",
 ]
 

--- a/src/conductor/cli/run.py
+++ b/src/conductor/cli/run.py
@@ -44,5 +44,5 @@ def main(args):
     )
     ctx.task_index.load_transitive_closure(task_identifier)
     plan = ExecutionPlan.for_task(task_identifier, ctx, run_again=args.again)
-    executor = Executor()
-    executor.run_plan(plan, ctx, stop_early=args.stop_early)
+    executor = Executor(execution_slots=1)
+    executor.run_plan(plan, ctx, stop_on_first_error=args.stop_early)

--- a/src/conductor/cli/run.py
+++ b/src/conductor/cli/run.py
@@ -1,8 +1,16 @@
+import multiprocessing
+
 from conductor.context import Context
+from conductor.errors import InvalidJobsCount, CannotSelectJobCount
 from conductor.task_identifier import TaskIdentifier
 from conductor.execution.executor import Executor
 from conductor.execution.plan import ExecutionPlan
 from conductor.utils.user_code import cli_command
+
+
+# Value used to indicate when Conductor should select the maximum number of
+# parallel tasks.
+_AUTOFILL_JOBS = -1
 
 
 def register_command(subparsers):
@@ -32,11 +40,38 @@ def register_command(subparsers):
         "rest of the task's dependencies that do not depend on the failed "
         "task.",
     )
+    parser.add_argument(
+        "-j",
+        "--jobs",
+        type=int,
+        nargs="?",
+        const=_AUTOFILL_JOBS,
+        default=None,
+        help="The maximum number of tasks that Conductor can run in parallel. "
+        "If this flag is used without specifying a value, Conductor will set "
+        "this number to be the number of virtual CPUs detected in this machine.",
+    )
     parser.set_defaults(func=main)
+
+
+def validate_and_retrieve_jobs_count(args) -> int:
+    if args.jobs is None:
+        return 1
+    elif args.jobs == _AUTOFILL_JOBS:
+        try:
+            return multiprocessing.cpu_count()
+        except ValueError as ex:
+            raise CannotSelectJobCount() from ex
+    else:
+        assert args.jobs is not None
+        if args.jobs <= 0:
+            raise InvalidJobsCount()
+        return args.jobs
 
 
 @cli_command
 def main(args):
+    num_jobs = validate_and_retrieve_jobs_count(args)
     ctx = Context.from_cwd()
     task_identifier = TaskIdentifier.from_str(
         args.task_identifier,
@@ -44,5 +79,5 @@ def main(args):
     )
     ctx.task_index.load_transitive_closure(task_identifier)
     plan = ExecutionPlan.for_task(task_identifier, ctx, run_again=args.again)
-    executor = Executor(execution_slots=1)
+    executor = Executor(execution_slots=num_jobs)
     executor.run_plan(plan, ctx, stop_on_first_error=args.stop_early)

--- a/src/conductor/config.py
+++ b/src/conductor/config.py
@@ -36,6 +36,11 @@ DEPS_ENV_PATH_SEPARATOR = ":"
 # The environment variable that stores the name of the task being executed.
 TASK_NAME_ENV_VARIABLE_NAME = "COND_NAME"
 
+# The environment variable that stores the "slot" number of the task being
+# executed. This variable is only set when the task may be running in parallel
+# with other tasks.
+SLOT_ENV_VARIABLE_NAME = "COND_SLOT"
+
 # A template for the default name of a Conductor archive.
 ARCHIVE_FILE_NAME_TEMPLATE = "cond-archive+{timestamp}.tar.gz"
 

--- a/src/conductor/errors/generated.py
+++ b/src/conductor/errors/generated.py
@@ -459,7 +459,33 @@ class UnsupportedPlatform(ConductorError):
 
     
     def _message(self):
-        return "Conductor only supports Linux and macOS.".format(
+        return "Conductor is not supported on your system. Conductor only supports Linux and macOS.".format(
+
+        )
+
+
+class InvalidJobsCount(ConductorError):
+    error_code = 5004
+
+    def __init__(self, **kwargs):
+        super().__init__()
+
+    
+    def _message(self):
+        return "The maximum number of parallel jobs must be at least 1.".format(
+
+        )
+
+
+class CannotSelectJobCount(ConductorError):
+    error_code = 5005
+
+    def __init__(self, **kwargs):
+        super().__init__()
+
+    
+    def _message(self):
+        return "Conductor could not automatically set the maximum number of parallel jobs. Please explicitly specify a number using the --jobs flag.".format(
 
         )
 
@@ -499,4 +525,6 @@ __all__ = [
     "ConfigParseError",
     "ConfigInvalidValue",
     "UnsupportedPlatform",
+    "InvalidJobsCount",
+    "CannotSelectJobCount",
 ]

--- a/src/conductor/execution/executor.py
+++ b/src/conductor/execution/executor.py
@@ -1,19 +1,117 @@
 import time
 import collections
-from typing import List
+import os
+import signal
+from typing import Dict, List, Iterable, Tuple
 
 from conductor.context import Context
-from conductor.errors import ConductorError, TaskNotFound, ConductorAbort
+from conductor.errors import ConductorError, ConductorAbort
 from conductor.execution.plan import ExecutionPlan
 from conductor.execution.task import ExecutingTask
 from conductor.execution.task_state import TaskState
+from conductor.task_types.base import TaskExecutionHandle
 from conductor.utils.time import time_to_readable_string
 
 
+class _ReadyToRunQueue:
+    def __init__(self):
+        self._sequential_tasks = collections.deque()
+        self._parallel_tasks = collections.deque()
+
+    def load(self, initial_tasks: Iterable[ExecutingTask]):
+        for task in initial_tasks:
+            self.enqueue_task(task)
+
+    def has_tasks(self) -> bool:
+        return (len(self._sequential_tasks) > 0) or (len(self._parallel_tasks) > 0)
+
+    def has_parallelizable_tasks(self) -> bool:
+        return len(self._parallel_tasks) > 0
+
+    def enqueue_task(self, task: ExecutingTask) -> None:
+        self._sequential_tasks.append(task)
+
+    def dequeue_next(self) -> ExecutingTask:
+        if self.has_parallelizable_tasks():
+            return self._parallel_tasks.popleft()
+        else:
+            return self._sequential_tasks.popleft()
+
+    def clear(self) -> None:
+        self._sequential_tasks.clear()
+        self._parallel_tasks.clear()
+
+
+class _InflightTasks:
+    def __init__(self):
+        self._processes: Dict[int, Tuple[TaskExecutionHandle, ExecutingTask]] = {}
+        self._sync_tasks: List[Tuple[TaskExecutionHandle, ExecutingTask]] = []
+
+    def add_task(self, handle: TaskExecutionHandle, task: ExecutingTask) -> None:
+        if handle.is_sync:
+            self._sync_tasks.append((handle, task))
+        else:
+            assert handle.pid is not None
+            self._processes[handle.pid] = (handle, task)
+
+    def __len__(self) -> int:
+        return len(self._processes) + len(self._sync_tasks)
+
+    def has_sync_tasks(self) -> bool:
+        return len(self._sync_tasks) > 0
+
+    def wait_for_next_task(self) -> Tuple[TaskExecutionHandle, ExecutingTask]:
+        if len(self._sync_tasks) > 0:
+            return self._sync_tasks.pop()
+
+        # Wait for the next child process to finish.
+        pid, status = os.wait()
+        assert pid in self._processes
+        handle, task = self._processes[pid]
+        del self._processes[pid]
+        if os.WIFEXITED(status):
+            exitcode = os.WEXITSTATUS(status)
+        elif os.WIFSIGNALED(status):
+            exitcode = os.WTERMSIG(status)
+        else:
+            raise AssertionError
+        handle.returncode = exitcode
+        return handle, task
+
+    def terminate_processes(self) -> None:
+        # Send SIGTERM to each process' process group (i.e., the subprocess and
+        # its child processes).
+        for handle, _ in self._processes.values():
+            if handle.pid is None:
+                continue
+            group_id = os.getpgid(handle.pid)
+            if group_id < 0:
+                continue
+            os.killpg(group_id, signal.SIGTERM)
+
+    def clear(self) -> None:
+        self.terminate_processes()
+        self._processes.clear()
+        self._sync_tasks.clear()
+
+
 class Executor:
-    def run_plan(self, plan: ExecutionPlan, ctx: Context, stop_early: bool = False):
-        start = time.time()
+    def __init__(self, execution_slots: int):
+        assert execution_slots > 0
+        self._slots = execution_slots
+
+        self._ready_to_run = _ReadyToRunQueue()
+        self._inflight_tasks = _InflightTasks()
+        self._completed_tasks: List[ExecutingTask] = []
+        self._running_parallel = False
+
+    def run_plan(
+        self, plan: ExecutionPlan, ctx: Context, stop_on_first_error: bool = False
+    ):
         try:
+            self._reset()
+            start = time.time()
+
             # 1. Print out any cached tasks.
             for cached_task in plan.cached_tasks:
                 print(
@@ -22,127 +120,179 @@ class Executor:
                     )
                 )
 
-            # A queue of tasks that are ready for execution (their dependencies
-            # have completed).
-            ready_to_run = collections.deque(plan.initial_tasks)
+            # 2. Run the tasks as they become eligible for execution.
+            should_stop = False
+            self._ready_to_run.load(plan.initial_tasks)
+            while self._ready_to_run.has_tasks() or len(self._inflight_tasks) > 0:
+                should_stop = self._launch_tasks_if_able(ctx, stop_on_first_error)
+                if should_stop:
+                    break
 
-            # Tracks tasks that have finished executing (succeeded,
-            # succeeded_cached, skipped, failed). The order of tasks in this
-            # list is the order they executed in.
-            completed_tasks: List[ExecutingTask] = []
+                if len(self._inflight_tasks) == 0:
+                    # There may be no in-flight tasks if the last ready-to-run
+                    # task failed or was skipped.
+                    continue
 
-            while len(ready_to_run) > 0:
-                next_task = ready_to_run.popleft()
-
-                # Make sure all dependencies succeeded. Otherwise we need to
-                # skip this task.
-                if not next_task.exe_deps_succeeded():
-                    print("Skipping {}.".format(str(next_task.task.identifier)))
-                    next_task.set_state(TaskState.SKIPPED)
-                else:
-                    # All dependencies have successfully run; can run now.
-                    print("Running {}...".format(str(next_task.task.identifier)))
-                    try:
-                        handle = next_task.task.start_execution(ctx)
-                        if not handle.already_completed:
-                            handle.get_process().wait()
-                        next_task.task.finish_execution(handle, ctx)
-                        next_task.set_state(TaskState.SUCCEEDED)
-                    except ConductorAbort:
-                        # User-initiated aborts are not treated as a task failure.
-                        ctx.version_index.rollback_changes()
-                        next_task.set_state(TaskState.ABORTED)
-                        raise
-                    except ConductorError as ex:
-                        # The task failed. Abort early if requested by
-                        # re-raising the error.
-                        ctx.version_index.rollback_changes()
-                        next_task.set_state(TaskState.FAILED)
-                        next_task.store_error(ex)
-                        if stop_early:
-                            # To allow the failure to be printed below.
-                            completed_tasks.append(next_task)
-                            break
-
-                completed_tasks.append(next_task)
-                # Enqueue any tasks that now become ready to run because this
-                # task executed.
-                next_task.decrement_deps_of_waiting_on()
-                for dep_of in next_task.deps_of:
-                    if dep_of.waiting_on > 0:
-                        continue
-                    ready_to_run.append(dep_of)
-
-            elapsed = time.time() - start
-
-            all_succeeded = all(map(lambda task: task.succeeded(), completed_tasks))
-            # We executed at least one task.
-            # The main task we wanted to run should always be the last
-            # completed task (its dependencies must be executed first).
-            main_task_executed = (
-                len(completed_tasks) > 0
-                and completed_tasks[-1].task.identifier
-                == plan.task_to_run.task.identifier
-            )
-            # We did not run any tasks, so the task we wanted to run
-            # must have been cached.
-            main_task_cached = (
-                len(completed_tasks) == 0
-                and plan.task_to_run.state == TaskState.SUCCEEDED_CACHED
-            )
-
-            # Print the final execution result (succeeded or failed).
-            if all_succeeded and (main_task_executed or main_task_cached):
-                print("✨ Done! (ran for {})".format(time_to_readable_string(elapsed)))
-
-            else:
-                # At least one task must have failed.
-                failed_tasks: List[ExecutingTask] = []
-                skipped_tasks: List[ExecutingTask] = []
-                for exe_task in completed_tasks:
-                    if exe_task.state == TaskState.SKIPPED:
-                        skipped_tasks.append(exe_task)
-                    elif exe_task.state == TaskState.FAILED:
-                        failed_tasks.append(exe_task)
-                assert len(failed_tasks) > 0
-                print(
-                    "🔴 Task failed. (ran for {})".format(
-                        time_to_readable_string(elapsed)
-                    )
+                should_stop = self._wait_for_next_inflight_task(
+                    ctx, stop_on_first_error
                 )
-                print()
-                print("Failed task(s):")
-                for failed in failed_tasks:
-                    print("  {}".format(failed.task.identifier))
-                    assert failed.stored_error is not None
-                    print(
-                        "    {}".format(
-                            failed.stored_error.printable_message(
-                                omit_file_context=True
-                            )
-                        )
-                    )
-                print()
-                if len(skipped_tasks) > 0:
-                    print("Skipped task(s) (one or more dependencies failed):")
-                    for skipped in skipped_tasks:
-                        print("  {}".format(skipped.task.identifier))
-                    print()
+                if should_stop:
+                    break
 
-                assert failed_tasks[0].stored_error is not None
-                raise failed_tasks[0].stored_error
+            # Only has an effect if we exited the loop above early due to
+            # encountering an error.
+            self._inflight_tasks.terminate_processes()
 
-        except TaskNotFound as ex:
-            # This should not happen. The task graph should be validated before
-            # execution.
-            ctx.version_index.rollback_changes()
-            raise AssertionError from ex
+            # 3. Report the results.
+            self._report_execution_results(plan, elapsed_time=(time.time() - start))
 
         except ConductorAbort:
-            ctx.version_index.rollback_changes()
+            self._inflight_tasks.terminate_processes()
             elapsed = time.time() - start
             print(
                 "🔸 Task aborted. (ran for {})".format(time_to_readable_string(elapsed))
             )
             print()
             raise
+
+    def _reset(self) -> None:
+        self._ready_to_run.clear()
+        self._completed_tasks.clear()
+        self._inflight_tasks.clear()
+        self._running_parallel = False
+
+    def _launch_tasks_if_able(self, ctx: Context, stop_on_first_error: bool) -> bool:
+        """
+        Launches as many tasks as possible while respecting the task's
+        parallelization setting and the number of execution slots available.
+
+        Returns `True` if an error occurs and `stop_on_first_error` is set to `True.
+        """
+        while True:
+            can_launch_any_ready_task = (
+                self._ready_to_run.has_tasks() and len(self._inflight_tasks) == 0
+            )
+            can_launch_parallelizable_task = (
+                self._running_parallel
+                and len(self._inflight_tasks) < self._slots
+                and self._ready_to_run.has_parallelizable_tasks()
+            )
+
+            if not can_launch_any_ready_task and not can_launch_parallelizable_task:
+                break
+
+            # Parallelizable tasks are prioritized (dequeued first).
+            next_task = self._ready_to_run.dequeue_next()
+            self._running_parallel = next_task.task.parallelizable
+
+            if not next_task.exe_deps_succeeded():
+                # At least one dependency failed, so we need to skip this task.
+                print("Skipping {}.".format(str(next_task.task.identifier)))
+                next_task.set_state(TaskState.SKIPPED)
+                self._process_finished_task(next_task)
+            else:
+                print("Running {}...".format(str(next_task.task.identifier)))
+                try:
+                    handle = next_task.task.start_execution(ctx)
+                    self._inflight_tasks.add_task(handle, next_task)
+                except ConductorAbort:
+                    next_task.set_state(TaskState.ABORTED)
+                    raise
+                except ConductorError as ex:
+                    next_task.store_error(ex)
+                    next_task.set_state(TaskState.FAILED)
+                    self._process_finished_task(next_task)
+                    if stop_on_first_error:
+                        return True
+
+        return False
+
+    def _wait_for_next_inflight_task(
+        self, ctx: Context, stop_on_first_error: bool
+    ) -> bool:
+        """
+        Waits for the next inflight task to complete (and processes it).
+
+        Returns `True` if an error occurs and `stop_on_first_error` is set to `True.
+        """
+        assert len(self._inflight_tasks) > 0
+
+        error_occurred = False
+        handle, task = self._inflight_tasks.wait_for_next_task()
+        try:
+            task.task.finish_execution(handle, ctx)
+            task.set_state(TaskState.SUCCEEDED)
+        except ConductorAbort:
+            task.set_state(TaskState.ABORTED)
+            raise
+        except ConductorError as ex:
+            task.store_error(ex)
+            task.set_state(TaskState.FAILED)
+            error_occurred = True
+        self._process_finished_task(task)
+
+        return error_occurred and stop_on_first_error
+
+    def _process_finished_task(self, finished_task: ExecutingTask) -> None:
+        self._completed_tasks.append(finished_task)
+        finished_task.decrement_deps_of_waiting_on()
+        for dep_of in finished_task.deps_of:
+            if dep_of.waiting_on > 0:
+                continue
+            self._ready_to_run.enqueue_task(dep_of)
+
+    def _report_execution_results(self, plan: ExecutionPlan, elapsed_time: float):
+        all_succeeded = all(map(lambda task: task.succeeded(), self._completed_tasks))
+        # We executed at least one task.
+        # The main task we wanted to run should always be the last
+        # completed task (its dependencies must be executed first).
+        main_task_executed = (
+            len(self._completed_tasks) > 0
+            and self._completed_tasks[-1].task.identifier
+            == plan.task_to_run.task.identifier
+        )
+        # We did not run any tasks, so the task we wanted to run
+        # must have been cached.
+        main_task_cached = (
+            len(self._completed_tasks) == 0
+            and plan.task_to_run.state == TaskState.SUCCEEDED_CACHED
+        )
+
+        # Print the final execution result (succeeded or failed).
+        if all_succeeded and (main_task_executed or main_task_cached):
+            print("✨ Done! (ran for {})".format(time_to_readable_string(elapsed_time)))
+
+        else:
+            # At least one task must have failed.
+            failed_tasks: List[ExecutingTask] = []
+            skipped_tasks: List[ExecutingTask] = []
+            for exe_task in self._completed_tasks:
+                if exe_task.state == TaskState.SKIPPED:
+                    skipped_tasks.append(exe_task)
+                elif exe_task.state == TaskState.FAILED:
+                    failed_tasks.append(exe_task)
+            assert len(failed_tasks) > 0
+            print(
+                "🔴 Task failed. (ran for {})".format(
+                    time_to_readable_string(elapsed_time)
+                )
+            )
+            print()
+            print("Failed task(s):")
+            for failed in failed_tasks:
+                print("  {}".format(failed.task.identifier))
+                assert failed.stored_error is not None
+                print(
+                    "    {}".format(
+                        failed.stored_error.printable_message(omit_file_context=True)
+                    )
+                )
+            print()
+            if len(skipped_tasks) > 0:
+                print("Skipped task(s) (one or more dependencies failed):")
+                for skipped in skipped_tasks:
+                    print("  {}".format(skipped.task.identifier))
+                print()
+
+            assert failed_tasks[0].stored_error is not None
+            raise failed_tasks[0].stored_error

--- a/src/conductor/execution/executor.py
+++ b/src/conductor/execution/executor.py
@@ -29,7 +29,10 @@ class _ReadyToRunQueue:
         return len(self._parallel_tasks) > 0
 
     def enqueue_task(self, task: ExecutingTask) -> None:
-        self._sequential_tasks.append(task)
+        if task.task.parallelizable:
+            self._parallel_tasks.append(task)
+        else:
+            self._sequential_tasks.append(task)
 
     def dequeue_next(self) -> ExecutingTask:
         if self.has_parallelizable_tasks():

--- a/src/conductor/execution/executor.py
+++ b/src/conductor/execution/executor.py
@@ -47,10 +47,6 @@ class Executor:
                         if not handle.already_completed:
                             handle.get_process().wait()
                         next_task.task.finish_execution(handle, ctx)
-                        # If this task succeeded, make sure we commit it to the
-                        # version index. This way if later tasks fail, we don't
-                        # restart from scratch.
-                        ctx.version_index.commit_changes()
                         next_task.set_state(TaskState.SUCCEEDED)
                     except ConductorAbort:
                         # User-initiated aborts are not treated as a task failure.

--- a/src/conductor/task_types/__init__.py
+++ b/src/conductor/task_types/__init__.py
@@ -8,14 +8,21 @@ from .run import RunCommand, RunExperiment
 _raw_task_types = [
     RawTaskType(
         name="run_command",
-        schema={"name": str, "run": str, "deps": [str]},
-        defaults={"deps": []},
+        schema={"name": str, "run": str, "parallelizable": bool, "deps": [str]},
+        defaults={"parallelizable": False, "deps": []},
         full_type=RunCommand,
     ),
     RawTaskType(
         name="run_experiment",
-        schema={"name": str, "run": str, "args": list, "options": dict, "deps": [str]},
-        defaults={"args": [], "options": {}, "deps": []},
+        schema={
+            "name": str,
+            "run": str,
+            "parallelizable": bool,
+            "args": list,
+            "options": dict,
+            "deps": [str],
+        },
+        defaults={"parallelizable": False, "args": [], "options": {}, "deps": []},
         full_type=RunExperiment,
     ),
     RawTaskType(

--- a/src/conductor/task_types/base.py
+++ b/src/conductor/task_types/base.py
@@ -1,10 +1,10 @@
 import pathlib
-from concurrent.futures import Future
 from typing import Callable, Dict, Sequence, Optional
 
 import conductor.context as c  # pylint: disable=unused-import
 import conductor.filename as f
 from conductor.task_identifier import TaskIdentifier
+from conductor.utils.output_handler import OutputHandler
 
 
 class TaskType:
@@ -143,8 +143,8 @@ class TaskExecutionHandle:
         pid: Optional[int],
     ):
         self.pid: Optional[int] = pid
-        self.stdout_tee: Optional[Future] = None
-        self.stderr_tee: Optional[Future] = None
+        self.stdout: Optional[OutputHandler] = None
+        self.stderr: Optional[OutputHandler] = None
         self.returncode: Optional[int] = None
         self.slot: Optional[int] = None
 

--- a/src/conductor/task_types/base.py
+++ b/src/conductor/task_types/base.py
@@ -83,7 +83,9 @@ class TaskType:
         """
         return True
 
-    def start_execution(self, ctx: "c.Context") -> "TaskExecutionHandle":
+    def start_execution(
+        self, ctx: "c.Context", slot: Optional[int]
+    ) -> "TaskExecutionHandle":
         """
         Start executing this task. Returns a handle that represents the
         execution. After the execution finishes, callers must invoke
@@ -144,6 +146,7 @@ class TaskExecutionHandle:
         self.stdout_tee: Optional[Future] = None
         self.stderr_tee: Optional[Future] = None
         self.returncode: Optional[int] = None
+        self.slot: Optional[int] = None
 
     @classmethod
     def from_async_process(cls, pid: int):

--- a/src/conductor/task_types/base.py
+++ b/src/conductor/task_types/base.py
@@ -98,7 +98,6 @@ class TaskType:
     def get_output_path(
         self,
         ctx: "c.Context",
-        create_new: bool = False,  # pylint: disable=unused-argument
     ) -> Optional[pathlib.Path]:
         """
         Returns the absolute path to this task's outputs directory. Note that
@@ -108,10 +107,6 @@ class TaskType:
         If the task supports multiple output versions (e.g.,
         `run_experiment`), this method returns the latest output path. The
         return value will be `None` if no such path exists.
-
-        The `create_new` argument is used by tasks that support multiple
-        output versions to indicate that a new output version directory
-        should be created. For all other tasks, `create_new` is ignored.
         """
         return ctx.output_path / self._output_path_suffix
 

--- a/src/conductor/task_types/combine.py
+++ b/src/conductor/task_types/combine.py
@@ -39,7 +39,7 @@ class Combine(TaskType):
         return super().__repr__() + ")"
 
     def start_execution(self, ctx: "c.Context") -> TaskExecutionHandle:
-        output_path = self.get_output_path(ctx, create_new=True)
+        output_path = self.get_output_path(ctx)
         assert output_path is not None
 
         for dep in self.deps:

--- a/src/conductor/task_types/combine.py
+++ b/src/conductor/task_types/combine.py
@@ -1,6 +1,6 @@
 import pathlib
 import shutil
-from typing import Sequence
+from typing import Sequence, Optional
 
 import conductor.context as c  # pylint: disable=unused-import
 from conductor.errors import CombineDuplicateDepName
@@ -38,7 +38,9 @@ class Combine(TaskType):
     def __repr__(self) -> str:
         return super().__repr__() + ")"
 
-    def start_execution(self, ctx: "c.Context") -> TaskExecutionHandle:
+    def start_execution(
+        self, ctx: "c.Context", slot: Optional[int]
+    ) -> TaskExecutionHandle:
         output_path = self.get_output_path(ctx)
         assert output_path is not None
 

--- a/src/conductor/task_types/group.py
+++ b/src/conductor/task_types/group.py
@@ -1,5 +1,5 @@
 import pathlib
-from typing import Sequence
+from typing import Sequence, Optional
 
 import conductor.context as c  # pylint: disable=unused-import
 from conductor.task_identifier import TaskIdentifier
@@ -20,7 +20,9 @@ class Group(TaskType):
     def __repr__(self) -> str:
         return super().__repr__() + ")"
 
-    def start_execution(self, ctx: "c.Context") -> TaskExecutionHandle:
+    def start_execution(
+        self, ctx: "c.Context", slot: Optional[int]
+    ) -> TaskExecutionHandle:
         # This task provides an "alias" for a group of other tasks (its
         # dependencies). As a result, it is a no-op.
         return TaskExecutionHandle.from_sync_execution()

--- a/src/conductor/task_types/stdlib/run_experiment_group.py
+++ b/src/conductor/task_types/stdlib/run_experiment_group.py
@@ -17,6 +17,7 @@ def run_experiment_group(
     name: str,
     run: str,
     experiments: Iterable[ExperimentInstance],
+    parallelizable: bool = False,
     deps: Optional[Sequence[str]] = None,
 ) -> None:
     task_deps = deps if deps is not None else []
@@ -38,6 +39,7 @@ def run_experiment_group(
             run_experiment(  # type: ignore
                 name=experiment.name,
                 run=run,
+                parallelizable=parallelizable,
                 args=experiment.args,
                 options=experiment.options,
                 deps=task_deps,

--- a/src/conductor/task_types/stdlib/run_experiment_group.py
+++ b/src/conductor/task_types/stdlib/run_experiment_group.py
@@ -11,13 +11,13 @@ class ExperimentInstance(NamedTuple):
     name: str
     args: List[ArgumentValue] = []
     options: Dict[str, OptionValue] = {}
+    parallelizable: bool = False
 
 
 def run_experiment_group(
     name: str,
     run: str,
     experiments: Iterable[ExperimentInstance],
-    parallelizable: bool = False,
     deps: Optional[Sequence[str]] = None,
 ) -> None:
     task_deps = deps if deps is not None else []
@@ -39,7 +39,7 @@ def run_experiment_group(
             run_experiment(  # type: ignore
                 name=experiment.name,
                 run=run,
-                parallelizable=parallelizable,
+                parallelizable=experiment.parallelizable,
                 args=experiment.args,
                 options=experiment.options,
                 deps=task_deps,

--- a/src/conductor/utils/output_handler.py
+++ b/src/conductor/utils/output_handler.py
@@ -1,0 +1,52 @@
+import enum
+import pathlib
+import subprocess
+from concurrent.futures import Future
+from typing import Optional, TextIO, IO
+
+import conductor.context as c  # pylint: disable=unused-import
+
+
+class RecordType(enum.Enum):
+    NotRecorded = 1
+    Teed = 2
+    OnlyLogged = 3
+
+
+class OutputHandler:
+    """
+    A utility class used for handling task output logging.
+    """
+
+    def __init__(self, output_path: pathlib.Path, record_type: RecordType):
+        self._output_path = output_path
+        self._type = record_type
+        self._file = None
+        self._tee_future: Optional[Future] = None
+
+    def popen_arg(self):
+        if self._type == RecordType.NotRecorded:
+            return None
+        elif self._type == RecordType.Teed:
+            return subprocess.PIPE
+        elif self._type == RecordType.OnlyLogged:
+            if self._file is None:
+                self._file = open(self._output_path, "wb")
+            return self._file
+
+    def maybe_tee(self, pipe: Optional[IO[bytes]], stream: TextIO, ctx: "c.Context"):
+        if self._type != RecordType.Teed:
+            return
+        assert pipe is not None
+        self._tee_future = ctx.tee_processor.tee_pipe(pipe, stream, self._output_path)
+
+    def finish(self):
+        if self._type == RecordType.Teed and self._tee_future is not None:
+            self._tee_future.result()
+            self._tee_future = None
+        elif self._type == RecordType.OnlyLogged and self._file is not None:
+            self._file.close()
+            self._file = None
+
+    def __del__(self):
+        self.finish()

--- a/src/conductor/utils/sigchld.py
+++ b/src/conductor/utils/sigchld.py
@@ -1,0 +1,67 @@
+import contextlib
+import errno
+import os
+import signal
+from typing import List, Optional, Tuple  # pylint: disable=unused-import
+
+
+class SigchldHelper:
+    _Instance: "Optional[SigchldHelper]" = None
+
+    @staticmethod
+    def instance() -> "SigchldHelper":
+        if SigchldHelper._Instance is None:
+            SigchldHelper._Instance = SigchldHelper()
+        return SigchldHelper._Instance
+
+    def __init__(self):
+        # Maps pids to return codes
+        self._returncodes: List[Tuple[int, int]] = []
+        self._read_pipe = None
+        self._write_pipe = None
+
+    @contextlib.contextmanager
+    def track(self):
+        self._read_pipe, self._write_pipe = os.pipe()
+        existing_handler = signal.signal(signal.SIGCHLD, SigchldHelper._handler)
+        try:
+            yield
+        finally:
+            signal.signal(signal.SIGCHLD, existing_handler)
+            os.close(self._write_pipe)
+            os.close(self._read_pipe)
+            self._returncodes.clear()
+            self._write_pipe = None
+            self._read_pipe = None
+
+    def wait(self) -> Tuple[int, int]:
+        _ = os.read(self._read_pipe, 1)
+        return self._extract_any()
+
+    def _add_returncode(self, pid: int, returncode: int) -> None:
+        self._returncodes.append((pid, returncode))
+        os.write(self._write_pipe, b"\0")
+
+    def _extract_any(self) -> Tuple[int, int]:
+        # Precondition: `self._returncodes` must be non-empty.
+        return self._returncodes.pop()
+
+    @staticmethod
+    def _handler(sig, frame) -> None:  # pylint: disable=unused-argument
+        try:
+            while True:
+                pid, status = os.waitpid(-1, os.WNOHANG)
+                if pid == 0 and status == 0:
+                    break
+
+                if os.WIFEXITED(status):
+                    returncode = os.WEXITSTATUS(status)
+                elif os.WIFSIGNALED(status):
+                    returncode = os.WTERMSIG(status)
+                else:
+                    raise AssertionError
+                # pylint: disable=protected-access
+                SigchldHelper.instance()._add_returncode(pid, returncode)
+        except OSError as ex:
+            if ex.errno != errno.ECHILD:
+                raise

--- a/src/conductor/utils/tee.py
+++ b/src/conductor/utils/tee.py
@@ -12,9 +12,6 @@ class TeeProcessor:
         self._executor = ThreadPoolExecutor(max_workers=2)
         self._has_shutdown = False
 
-    def __del__(self):
-        self.shutdown()
-
     def shutdown(self):
         if self._has_shutdown:
             return

--- a/tests/cond_run_parallel_test.py
+++ b/tests/cond_run_parallel_test.py
@@ -1,0 +1,140 @@
+import pathlib
+import shutil
+import subprocess
+from typing import Any, Iterable
+
+from conductor.config import TASK_OUTPUT_DIR_SUFFIX, STDOUT_LOG_FILE, STDERR_LOG_FILE
+from .conductor_runner import ConductorRunner, FIXTURE_TEMPLATES
+
+
+def extract_logged_slot(result_path: pathlib.Path) -> int:
+    slots_file = result_path / "slot.txt"
+    assert slots_file.exists()
+    with open(slots_file, encoding="UTF-8") as f:
+        return int(f.read().strip())
+
+
+def test_invalid_jobs(tmp_path: pathlib.Path):
+    cond = ConductorRunner.from_template(tmp_path, FIXTURE_TEMPLATES["experiments"])
+    # When specified, the number of jobs has to be at least 1.
+    result = cond.run("//parallel:three", jobs=0)
+    assert result.returncode != 0
+    result = cond.run("//parallel:three", jobs=-10)
+    assert result.returncode != 0
+
+
+def test_run_parallel(tmp_path: pathlib.Path):
+    cond = ConductorRunner.from_template(tmp_path, FIXTURE_TEMPLATES["experiments"])
+    result = cond.run("//parallel:three", jobs=3)
+    assert result.returncode == 0
+
+    outputs = cond.output_path / "parallel" / ("three" + TASK_OUTPUT_DIR_SUFFIX)
+    paths = [
+        (outputs / "three-0"),
+        (outputs / "three-1"),
+        (outputs / "three-2"),
+    ]
+    assert all(map(lambda p: p.is_dir(), paths))
+
+    seen_slots = set()
+    for idx, out_dir in enumerate(paths):
+        slot = extract_logged_slot(out_dir)
+        seen_slots.add(slot)
+
+        arg_file = out_dir / "arg1.txt"
+        assert arg_file.exists()
+        with open(arg_file, encoding="UTF-8") as f:
+            arg = int(f.read().strip())
+        assert arg == idx
+
+        # Even if running in parallel, we should still log the task's output on
+        # stdout and stderr.
+        stdout_file = out_dir / STDOUT_LOG_FILE
+        assert stdout_file.exists()
+        with open(stdout_file, encoding="UTF-8") as f:
+            parts = f.read().strip().split(" ")
+        assert parts[0] == "stdout"
+        assert int(parts[1]) == slot
+
+        stderr_file = out_dir / STDERR_LOG_FILE
+        assert stderr_file.exists()
+        with open(stderr_file, encoding="UTF-8") as f:
+            parts = f.read().strip().split(" ")
+        assert parts[0] == "stderr"
+        assert int(parts[1]) == slot
+
+    # We ran with 3 jobs, so the three tasks should have been allowed to run in
+    # parallel.
+    assert len(seen_slots) == 3
+
+
+def test_run_parallel_fewer_slots(tmp_path: pathlib.Path):
+    cond = ConductorRunner.from_template(tmp_path, FIXTURE_TEMPLATES["experiments"])
+    result = cond.run("//parallel:three", jobs=2)
+    assert result.returncode == 0
+
+    outputs = cond.output_path / "parallel" / ("three" + TASK_OUTPUT_DIR_SUFFIX)
+    paths = [
+        (outputs / "three-0"),
+        (outputs / "three-1"),
+        (outputs / "three-2"),
+    ]
+    assert all(map(lambda p: p.is_dir(), paths))
+
+    seen_slots = set()
+    for idx, out_dir in enumerate(paths):
+        slot = extract_logged_slot(out_dir)
+        seen_slots.add(slot)
+
+        arg_file = out_dir / "arg1.txt"
+        assert arg_file.exists()
+        with open(arg_file, encoding="UTF-8") as f:
+            arg = int(f.read().strip())
+        assert arg == idx
+
+    # At most two tasks run in parallel.
+    assert len(seen_slots) == 2
+
+
+def test_run_parallel_but_sequential(tmp_path: pathlib.Path):
+    cond = ConductorRunner.from_template(tmp_path, FIXTURE_TEMPLATES["experiments"])
+    # This task is parallelizable, but we restrict Conductor to running no more
+    # than a single task at a time. There should be no slot number passed to the
+    # task (to indicate sequential execution).
+    result = cond.run("//parallel:three", jobs=1)
+    assert result.returncode == 0
+
+    outputs = cond.output_path / "parallel" / ("three" + TASK_OUTPUT_DIR_SUFFIX)
+    paths = [
+        (outputs / "three-0"),
+        (outputs / "three-1"),
+        (outputs / "three-2"),
+    ]
+    assert all(map(lambda p: p.is_dir(), paths))
+
+    # No slot printed.
+    for out_dir in paths:
+        with open(out_dir / "slot.txt") as f:
+            assert f.read().strip() == ""
+
+
+def test_run_sequential_multiple_jobs(tmp_path: pathlib.Path):
+    cond = ConductorRunner.from_template(tmp_path, FIXTURE_TEMPLATES["experiments"])
+    # This task is NOT parallelizable, but we set jobs to be greater than 1.
+    # Regardless, there should be no slot number passed to the task (to indicate
+    # sequential execution).
+    result = cond.run("//parallel:three_seq", jobs=5)
+    assert result.returncode == 0
+
+    outputs = cond.output_path / "parallel" / ("three_seq" + TASK_OUTPUT_DIR_SUFFIX)
+    paths = [
+        (outputs / "three_seq-0"),
+        (outputs / "three_seq-1"),
+        (outputs / "three_seq-2"),
+    ]
+    assert all(map(lambda p: p.is_dir(), paths))
+
+    # No slot printed.
+    for out_dir in paths:
+        with open(out_dir / "slot.txt") as f:
+            assert f.read().strip() == ""

--- a/tests/conductor_runner.py
+++ b/tests/conductor_runner.py
@@ -48,12 +48,16 @@ class ConductorRunner:
         task_identifier: str,
         again: bool = False,
         stop_early: bool = False,
+        jobs: Optional[int] = None,
     ) -> subprocess.CompletedProcess:
         cmd = ["run", task_identifier]
         if again:
             cmd.append("--again")
         if stop_early:
             cmd.append("--stop-early")
+        if jobs is not None:
+            cmd.append("--jobs")
+            cmd.append(str(jobs))
         return self._run_command(cmd)
 
     def clean(self) -> subprocess.CompletedProcess:

--- a/tests/fixture-projects/experiments/parallel/COND
+++ b/tests/fixture-projects/experiments/parallel/COND
@@ -1,0 +1,25 @@
+run_experiment_group(
+  name="three",
+  run="./test.sh",
+  experiments=[
+    ExperimentInstance(
+      name="three-{}".format(i),
+      args=[str(i)],
+      parallelizable=True,
+    )
+    for i in range(3)
+  ],
+)
+
+run_experiment_group(
+  name="three_seq",
+  run="./test.sh",
+  experiments=[
+    ExperimentInstance(
+      name="three_seq-{}".format(i),
+      args=[str(i)],
+      parallelizable=False,
+    )
+    for i in range(3)
+  ],
+)

--- a/tests/fixture-projects/experiments/parallel/COND
+++ b/tests/fixture-projects/experiments/parallel/COND
@@ -23,3 +23,16 @@ run_experiment_group(
     for i in range(3)
   ],
 )
+
+run_experiment_group(
+  name="three_may_fail",
+  run="./test-may-fail.sh",
+  experiments=[
+    ExperimentInstance(
+      name="three_may_fail-{}".format(i),
+      args=[str(i)],
+      parallelizable=True,
+    )
+    for i in range(6)
+  ],
+)

--- a/tests/fixture-projects/experiments/parallel/COND
+++ b/tests/fixture-projects/experiments/parallel/COND
@@ -36,3 +36,33 @@ run_experiment_group(
     for i in range(6)
   ],
 )
+
+group(
+  name="three_after",
+  deps=[
+    ":three_after-0",
+    ":three_after-1",
+    ":three_after-2",
+  ],
+)
+
+run_experiment(
+  name="three_after-0",
+  run="./test-after.sh",
+  parallelizable=True,
+  deps=[":three-0"],
+)
+
+run_experiment(
+  name="three_after-1",
+  run="./test-after.sh",
+  parallelizable=True,
+  deps=[":three-1"],
+)
+
+run_experiment(
+  name="three_after-2",
+  run="./test-after.sh",
+  parallelizable=True,
+  deps=[":three-2"],
+)

--- a/tests/fixture-projects/experiments/parallel/test-after.sh
+++ b/tests/fixture-projects/experiments/parallel/test-after.sh
@@ -1,0 +1,8 @@
+#! /bin/bash
+
+if [ -f "$COND_DEPS/slot.txt" ]; then
+  echo $COND_SLOT > $COND_OUT/slot.txt
+else
+  echo "Dependency slot.txt did not exist!" >&2
+  exit 1
+fi

--- a/tests/fixture-projects/experiments/parallel/test-may-fail.sh
+++ b/tests/fixture-projects/experiments/parallel/test-may-fail.sh
@@ -1,0 +1,13 @@
+#! /bin/bash
+
+echo $COND_SLOT > $COND_OUT/slot.txt
+echo $1 > $COND_OUT/arg1.txt
+
+if [ "$(($1 % 2))" -eq 0 ]; then
+  # This script exits with a non-zero code if the first argument is
+  # even.
+  exit 1
+else
+  echo "stdout $COND_SLOT"
+  echo "stderr $COND_SLOT" >&2
+fi

--- a/tests/fixture-projects/experiments/parallel/test.sh
+++ b/tests/fixture-projects/experiments/parallel/test.sh
@@ -1,0 +1,6 @@
+#! /bin/bash
+
+echo $COND_SLOT > $COND_OUT/slot.txt
+echo $1 > $COND_OUT/arg1.txt
+echo "stdout $COND_SLOT"
+echo "stderr $COND_SLOT" >&2


### PR DESCRIPTION
Tasks need to explicitly declare that they are parallelizable through the `parallelizable` keyword argument in `run_experiment()`, `run_command()`, and `ExperimentInstance()`. Parallelizable tasks will only be scheduled to run in parallel with other parallelizable tasks.