### PR TITLE
[Execution] Implement new environment task type

### DIFF
--- a/src/conductor/parsing/validation.py
+++ b/src/conductor/parsing/validation.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict
+from typing import Any, Callable, Dict, Union, get_origin, get_args
 
 from conductor.errors import (
     InvalidTaskParameterType,
@@ -12,16 +12,29 @@ def generate_type_validator(
 ) -> Callable[[Dict[str, Any]], None]:
     def validate(arguments: Dict[str, Any]) -> None:
         for parameter, type_class in schema.items():
-            # 1. If we do not find the parameter, it's an error
+            # 1. If we do not find the parameter (and it is not marked
+            # `Optional`), it's an error
             if parameter not in arguments:
+                if _is_optional(type_class):
+                    # Optional value not included.
+                    continue
                 raise MissingTaskParameter(
                     parameter_name=parameter,
                     task_type_name=task_type_name,
                 )
 
+            # Get the "inner type" if it is optional.
+            if _is_optional(type_class):
+                if arguments[parameter] is None:
+                    # Optional value is `None`.
+                    continue
+                expected_type = get_args(type_class)
+            else:
+                expected_type = type_class
+
             # 2. For lists, we need to check that its contents are all a
             #    predefined type
-            if isinstance(type_class, list):
+            if isinstance(expected_type, list):
                 if not isinstance(arguments[parameter], list):
                     raise InvalidTaskParameterType(
                         parameter_name=parameter,
@@ -31,7 +44,7 @@ def generate_type_validator(
 
                 item_valid = map(
                     # pylint: disable=cell-var-from-loop
-                    lambda el: isinstance(el, type_class[0]),
+                    lambda el: isinstance(el, expected_type[0]),
                     arguments[parameter],
                 )
 
@@ -43,15 +56,24 @@ def generate_type_validator(
                     )
 
             # 3. Otherwise, just check the parameter type
-            elif not isinstance(arguments[parameter], type_class):
+            elif not isinstance(arguments[parameter], expected_type):
                 raise InvalidTaskParameterType(
                     parameter_name=parameter,
-                    type_name=type_class.__name__,
+                    type_name=(
+                        type_class.__name__
+                        if hasattr(type_class, "__name__")
+                        else repr(type_class)
+                    ),
                     task_type_name=task_type_name,
                 )
 
         # 4. Ensure that no extraneous arguments are passed in
-        if len(arguments) != len(schema):
-            raise UnrecognizedTaskParameters(task_type_name=task_type_name)
+        for arg in arguments:
+            if arg not in schema:
+                raise UnrecognizedTaskParameters(task_type_name=task_type_name)
 
     return validate
+
+
+def _is_optional(field):
+    return get_origin(field) is Union and type(None) in get_args(field)

--- a/src/conductor/task_types/__init__.py
+++ b/src/conductor/task_types/__init__.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, Optional
 
 from .combine import Combine
 from .environment import Environment
@@ -53,15 +53,11 @@ _raw_task_types = [
             "start": str,
             "stop": str,
             "destroy": str,
-            "project_root": str,
+            "project_root": Optional[str],
             "mirrored_files": bool,
         },
         defaults={
-            "create": "",
-            "start": "",
-            "stop": "",
-            "destroy": "",
-            "project_root": "",
+            "project_root": None,
             "mirrored_files": False,
         },
         full_type=Environment,

--- a/src/conductor/task_types/__init__.py
+++ b/src/conductor/task_types/__init__.py
@@ -1,6 +1,7 @@
 from typing import Dict
 
 from .combine import Combine
+from .environment import Environment
 from .group import Group
 from .raw import RawTaskType
 from .run import RunCommand, RunExperiment
@@ -43,6 +44,27 @@ _raw_task_types = [
         schema={"name": str, "deps": [str]},
         defaults={"deps": []},
         full_type=Combine,
+    ),
+    RawTaskType(
+        name="environment",
+        schema={
+            "name": str,
+            "create": str,
+            "start": str,
+            "stop": str,
+            "destroy": str,
+            "project_root": str,
+            "mirrored_files": bool,
+        },
+        defaults={
+            "create": "",
+            "start": "",
+            "stop": "",
+            "destroy": "",
+            "project_root": "",
+            "mirrored_files": False,
+        },
+        full_type=Environment,
     ),
 ]
 

--- a/src/conductor/task_types/environment.py
+++ b/src/conductor/task_types/environment.py
@@ -11,10 +11,23 @@ class Environment(TaskType):
         self,
         identifier: TaskIdentifier,
         cond_file_path: pathlib.Path,
+        create: str,
+        start: str,
+        stop: str,
+        destroy: str,
+        project_root: Optional[str],
+        mirrored_files: bool,
     ):
         super().__init__(identifier=identifier, cond_file_path=cond_file_path, deps=[])
+        self._create = create
+        self._start = start
+        self._stop = stop
+        self._destroy = destroy
+        self._project_root = project_root
+        self._mirrored_files = mirrored_files
 
     def __repr__(self) -> str:
+        # To reduce verbosity, we do not print out the other properties.
         return super().__repr__() + ")"
 
     def start_execution(

--- a/src/conductor/task_types/environment.py
+++ b/src/conductor/task_types/environment.py
@@ -1,0 +1,32 @@
+import pathlib
+from typing import Optional
+
+import conductor.context as c  # pylint: disable=unused-import
+from conductor.task_identifier import TaskIdentifier
+from .base import TaskExecutionHandle, TaskType
+
+
+class Environment(TaskType):
+    def __init__(
+        self,
+        identifier: TaskIdentifier,
+        cond_file_path: pathlib.Path,
+    ):
+        super().__init__(identifier=identifier, cond_file_path=cond_file_path, deps=[])
+
+    def __repr__(self) -> str:
+        return super().__repr__() + ")"
+
+    def start_execution(
+        self, ctx: "c.Context", slot: Optional[int]
+    ) -> TaskExecutionHandle:
+        # No-op.
+        return TaskExecutionHandle.from_sync_execution()
+
+    def finish_execution(self, handle: "TaskExecutionHandle", ctx: "c.Context") -> None:
+        # Nothing special needs to be done here.
+        pass
+
+    def get_output_path(self, ctx: "c.Context") -> Optional[pathlib.Path]:
+        # This task does not have any outputs.
+        return None

--- a/tests/validation_test.py
+++ b/tests/validation_test.py
@@ -1,4 +1,5 @@
 import pytest
+from typing import Optional
 
 from conductor.errors import (
     InvalidTaskParameterType,
@@ -19,6 +20,12 @@ def simple_schema_validator():
 @pytest.fixture
 def schema_with_lists_validator():
     schema = {"prop": str, "strlist": [str], "intlist": [int]}
+    return generate_type_validator("Task", schema)
+
+
+@pytest.fixture
+def schema_with_optional_validator():
+    schema = {"prop": str, "prop2": Optional[str]}
     return generate_type_validator("Task", schema)
 
 
@@ -76,3 +83,20 @@ def test_list_wrong_type(schema_with_lists_validator):
         schema_with_lists_validator(
             {"prop": "hello", "strlist": [123, False, True], "intlist": [1, 2, 3]}
         )
+
+
+def test_optional_not_included(schema_with_optional_validator):
+    schema_with_optional_validator({"prop": "hello"})
+
+
+def test_optional_included_as_none(schema_with_optional_validator):
+    schema_with_optional_validator({"prop": "hello", "prop2": None})
+
+
+def test_optional_included_incorrectly(schema_with_optional_validator):
+    with pytest.raises(InvalidTaskParameterType):
+        schema_with_optional_validator({"prop": "hello", "prop2": 2})
+
+
+def test_optional_included(schema_with_optional_validator):
+    schema_with_optional_validator({"prop": "hello", "prop2": "world"})


### PR DESCRIPTION
Note that "task type" is a misnomer - this is just an environment definition that uses the same syntax style as a regular task type. We will need to refactor Conductor's internals to support a better abstraction (the DSL vs. physical execution runnables).

Resolves #98.