### PR TITLE
[Execution] Implement TaskType -> Operation planner

### DIFF
--- a/src/conductor/execution/plan2.py
+++ b/src/conductor/execution/plan2.py
@@ -1,0 +1,25 @@
+from typing import List
+
+from conductor.execution.ops.operation import Operation
+from conductor.task_types.base import TaskType
+
+
+class ExecutionPlan2:
+    """
+    Represents a plan for executing a task, including its dependencies.
+    """
+
+    # NOTE: This will replace `ExecutionPlan` after the refactor.
+
+    def __init__(
+        self,
+        *,
+        task_to_run: TaskType,
+        all_ops: List[Operation],
+        initial_ops: List[Operation],
+        cached_tasks: List[TaskType],
+    ) -> None:
+        self.task_to_run = task_to_run
+        self.all_ops = all_ops
+        self.initial_ops = initial_ops
+        self.cached_tasks = cached_tasks

--- a/src/conductor/execution/planning/lowering.py
+++ b/src/conductor/execution/planning/lowering.py
@@ -1,0 +1,33 @@
+import enum
+from typing import List
+
+from conductor.task_types.base import TaskType
+from conductor.execution.ops.operation import Operation
+
+
+class LoweringState(enum.Enum):
+    FIRST_VISIT = 0
+    SECOND_VISIT = 1
+
+
+class LoweringTask:
+    """
+    This class is used to track metadata about a task while we are converting
+    (lowering) a task graph into an operation graph.
+    """
+
+    @classmethod
+    def initial(cls, task: TaskType) -> "LoweringTask":
+        return cls(task, LoweringState.FIRST_VISIT)
+
+    def __init__(self, task: TaskType, state: LoweringState):
+        self.task = task
+        self.state = state
+
+        # A list of tasks that this task depends on.
+        self.deps: List["LoweringTask"] = []
+
+        # The "final" `Operation`s that represent this task. A task can be
+        # convered into more than one operation; tasks that depend on this task
+        # should take a dependency on these operations.
+        self.output_ops: List[Operation] = []

--- a/src/conductor/execution/planning/planner.py
+++ b/src/conductor/execution/planning/planner.py
@@ -1,0 +1,157 @@
+from typing import Dict, List, Optional
+
+from conductor.context import Context
+from conductor.execution.ops.combine_outputs import CombineOutputs
+from conductor.execution.ops.operation import Operation
+from conductor.execution.ops.run_task_executable import RunTaskExecutable
+from conductor.execution.planning.lowering import LoweringTask, LoweringState
+from conductor.execution.plan2 import ExecutionPlan2
+from conductor.execution.task_state import TaskState
+from conductor.task_identifier import TaskIdentifier
+from conductor.task_types.base import TaskType
+from conductor.task_types.group import Group
+from conductor.task_types.combine import Combine
+from conductor.task_types.run import RunCommand, RunExperiment
+
+
+class ExecutionPlanner:
+    def __init__(self, ctx: Context) -> None:
+        self._ctx = ctx
+
+    def create_plan_for(
+        self,
+        task_id: TaskIdentifier,
+        run_again: bool = False,
+        at_least_commit: Optional[str] = None,
+    ) -> "ExecutionPlan2":
+        """
+        Creates an `ExecutionPlan2` for the given task.
+
+        This function converts the task graph into a physical operation graph,
+        eliminating tasks that do not need to execute (due to having cached
+        results).
+        """
+
+        all_ops: List[Operation] = []
+        initial_operations: List[Operation] = []
+        cached_tasks: List[TaskType] = []
+        task_to_run = self._ctx.task_index.get_task(task_id)
+
+        # First pass (depth first):
+        # 1. Prune tasks that do not need to execute (due to having cached results).
+        # 2. Link task dependencies.
+        root = LoweringTask.initial(task_to_run)
+        stack = [root]
+        visited: Dict[TaskIdentifier, LoweringTask] = {}
+        while len(stack) > 0:
+            lt = stack.pop()
+
+            if lt.state == LoweringState.FIRST_VISIT:
+                # First visit to this task.
+                visited[lt.task.identifier] = lt
+
+                if not run_again and not lt.task.should_run(self._ctx, at_least_commit):
+                    # This task does not need to be executed again, so we do not
+                    # traverse further.
+                    cached_tasks.append(lt.task)
+                    continue
+
+                lt.state = LoweringState.SECOND_VISIT
+                stack.append(lt)
+
+                # Append in reverse order because we pop from the back of the
+                # list. This ensures we process dependencies in the order they
+                # are listed in the COND file (for the user's convenience).
+                for dep_ident in reversed(lt.task.deps):
+                    if dep_ident in visited:
+                        # Add the dependency relationship, but do not traverse
+                        # its dependencies because we already visited.
+                        dep = visited[dep_ident]
+                        lt.deps.append(dep)
+                        continue
+
+                    dep = LoweringTask.initial(self._ctx.task_index.get_task(dep_ident))
+                    lt.deps.append(dep)
+                    stack.append(dep)
+
+            elif lt.state == LoweringState.SECOND_VISIT:
+                if isinstance(lt.task, Group):
+                    # No operation needed because there is nothing to run; we
+                    # just need to propagate the dependencies forward.
+                    for dep in lt.deps:
+                        lt.output_ops.extend(dep.output_ops)
+
+                else:
+                    # These task types always produce at least one `Operation`.
+                    if isinstance(lt.task, RunExperiment):
+                        exp_version = lt.task.create_new_version(self._ctx)
+                        output_path = lt.task.get_output_path(self._ctx)
+                        assert output_path is not None
+                        new_op: Operation = RunTaskExecutable(
+                            initial_state=TaskState.QUEUED,
+                            identifier=lt.task.identifier,
+                            run=lt.task.raw_run,
+                            args=lt.task.args,
+                            options=lt.task.options,
+                            working_path=lt.task.get_working_path(self._ctx),
+                            output_path=output_path,
+                            deps_output_paths=lt.task.get_deps_output_paths(self._ctx),
+                            record_output=True,
+                            version_to_record=exp_version,
+                            serialize_args_options=True,
+                            parallelizable=lt.task.parallelizable,
+                        )
+
+                    elif isinstance(lt.task, RunCommand):
+                        output_path = lt.task.get_output_path(self._ctx)
+                        assert output_path is not None
+                        new_op = RunTaskExecutable(
+                            initial_state=TaskState.QUEUED,
+                            identifier=lt.task.identifier,
+                            run=lt.task.raw_run,
+                            args=lt.task.args,
+                            options=lt.task.options,
+                            working_path=lt.task.get_working_path(self._ctx),
+                            output_path=output_path,
+                            deps_output_paths=lt.task.get_deps_output_paths(self._ctx),
+                            record_output=False,
+                            version_to_record=None,
+                            serialize_args_options=False,
+                            parallelizable=lt.task.parallelizable,
+                        )
+
+                    elif isinstance(lt.task, Combine):
+                        output_path = lt.task.get_output_path(self._ctx)
+                        assert output_path is not None
+                        new_op = CombineOutputs(
+                            initial_state=TaskState.QUEUED,
+                            identifier=lt.task.identifier,
+                            output_path=output_path,
+                            deps_output_paths=lt.task.get_deps_output_paths(self._ctx),
+                        )
+
+                    else:
+                        # This indicates a bug: we added a new task type but did
+                        # not update the planner.
+                        raise NotImplementedError(f"Unsupported task type: {lt.task}")
+
+                    # Hook the new dependency into the graph.
+                    for dep in lt.deps:
+                        for dep_op in dep.output_ops:
+                            new_op.add_exe_dep(dep_op)
+                            dep_op.add_dep_of(new_op)
+                    lt.output_ops.append(new_op)
+
+                    # If this operation has no dependencies, it is part of
+                    # `initial_operations`.
+                    if len(lt.deps) == 0:
+                        initial_operations.append(new_op)
+
+                    all_ops.append(new_op)
+
+        return ExecutionPlan2(
+            task_to_run=task_to_run,
+            all_ops=all_ops,
+            initial_ops=initial_operations,
+            cached_tasks=cached_tasks,
+        )

--- a/src/conductor/task_types/base.py
+++ b/src/conductor/task_types/base.py
@@ -129,7 +129,7 @@ class TaskType:
             deps_output_paths.append(path)
         return deps_output_paths
 
-    def _get_working_path(self, ctx: "c.Context") -> pathlib.Path:
+    def get_working_path(self, ctx: "c.Context") -> pathlib.Path:
         return pathlib.Path(ctx.project_root, self._identifier.path)
 
 


### PR DESCRIPTION
This is part of the task type refactor: decoupling task types from the physical "operations" needed to execute a task graph.

Part of #99.