### PR TITLE
[Envs][Execution] Add general task archival/restore utilities and refactor existing code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ src/conductor_cli.egg-info
 .mypy_cache
 build
 dist
+env
 
 cond-out
 

--- a/errors/errors.yml
+++ b/errors/errors.yml
@@ -184,6 +184,12 @@
     The provided archive contains task output(s) that already exist in the output
     directory '{output_dir}'.
 
+4007:
+  name: UnsupportedArchiveType
+  message: >-
+    The provided archive file was compressed as {archive_type}, which is not
+    supported on your platform.
+
 
 # General Conductor errors (error code 5xxx)
 5001:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ exclude = '''
   | src/conductor/errors/generated.py
   | src/conductor/envs/proto_gen/
   | explorer/
+  | env/
 )
 '''
 

--- a/src/conductor/cli/archive.py
+++ b/src/conductor/cli/archive.py
@@ -12,7 +12,11 @@ from conductor.errors import (
 from conductor.task_identifier import TaskIdentifier
 from conductor.task_types.base import TaskType
 from conductor.utils.user_code import cli_command
-from conductor.utils.output_archiving import create_archive
+from conductor.utils.output_archiving import (
+    create_archive,
+    platform_archive_type,
+    ArchiveType,
+)
 
 
 def register_command(subparsers):
@@ -46,16 +50,18 @@ def register_command(subparsers):
     parser.set_defaults(func=main)
 
 
-def generate_archive_name() -> str:
+def generate_archive_name(archive_type: ArchiveType) -> str:
     timestamp = datetime.datetime.now().strftime("%Y-%m-%d+%H-%M-%S")
-    return f.archive(timestamp=timestamp)
+    return f.archive(timestamp=timestamp, archive_type=archive_type)
 
 
-def handle_output_path(ctx: Context, raw_output_path: Optional[str]) -> pathlib.Path:
+def handle_output_path(
+    ctx: Context, raw_output_path: Optional[str], archive_type: ArchiveType
+) -> pathlib.Path:
     if raw_output_path is None:
         output_path = pathlib.Path(
             ctx.output_path,
-            generate_archive_name(),
+            generate_archive_name(archive_type),
         )
         return output_path
 
@@ -67,7 +73,7 @@ def handle_output_path(ctx: Context, raw_output_path: Optional[str]) -> pathlib.
         if output_path.is_dir():
             # Corresponds to the case where the user provides a path to a
             # directory where the archive should be stored
-            return output_path / generate_archive_name()
+            return output_path / generate_archive_name(archive_type)
         raise OutputFileExists()
 
     elif output_path.parent.exists() and output_path.parent.is_dir():
@@ -105,7 +111,8 @@ def compute_tasks_to_archive(
 @cli_command
 def main(args):
     ctx = Context.from_cwd()
-    output_archive_path = handle_output_path(ctx, args.output)
+    archive_type = platform_archive_type()
+    output_archive_path = handle_output_path(ctx, args.output, archive_type)
 
     # If `None`, we should archive all tasks
     tasks_to_archive = compute_tasks_to_archive(ctx, args.task_identifier)
@@ -119,7 +126,9 @@ def main(args):
         if len(tasks_to_archive_with_versions) == 0:
             raise NoTaskOutputsToArchive()
 
-        create_archive(ctx, tasks_to_archive_with_versions, output_archive_path)
+        create_archive(
+            ctx, tasks_to_archive_with_versions, output_archive_path, archive_type
+        )
 
         # Compute a relative path to the current working directory, if possible
         try:

--- a/src/conductor/cli/restore.py
+++ b/src/conductor/cli/restore.py
@@ -1,5 +1,4 @@
 import pathlib
-import subprocess
 
 from conductor.context import Context
 from conductor.errors import ArchiveFileInvalid
@@ -17,23 +16,12 @@ def register_command(subparsers):
         type=str,
         help="Path to the archive file to restore.",
     )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="If set, the restore operation will fail if any task output is already present.",
+    )
     parser.set_defaults(func=main)
-
-
-def extract_archive(archive_file: pathlib.Path, staging_path: pathlib.Path):
-    try:
-        process = subprocess.Popen(
-            ["tar", "xzf", str(archive_file), "-C", str(staging_path)],
-            shell=False,
-        )
-        process.wait()
-        if process.returncode != 0:
-            raise ArchiveFileInvalid().add_extra_context(
-                "The tar utility returned a non-zero error code."
-            )
-
-    except OSError as ex:
-        raise ArchiveFileInvalid().add_extra_context(str(ex))
 
 
 @cli_command
@@ -44,4 +32,4 @@ def main(args):
     if not archive_file.is_file():
         raise ArchiveFileInvalid()
 
-    restore_archive(ctx, archive_file)
+    restore_archive(ctx, archive_file, expect_no_duplicates=args.strict)

--- a/src/conductor/cli/restore.py
+++ b/src/conductor/cli/restore.py
@@ -1,14 +1,10 @@
 import pathlib
 import subprocess
-import shutil
-import sqlite3
 
-import conductor.filename as f
-from conductor.config import ARCHIVE_STAGING, ARCHIVE_VERSION_INDEX
 from conductor.context import Context
-from conductor.errors import ArchiveFileInvalid, DuplicateTaskOutput
-from conductor.execution.version_index import VersionIndex
+from conductor.errors import ArchiveFileInvalid
 from conductor.utils.user_code import cli_command
+from conductor.utils.output_archiving import restore_archive
 
 
 def register_command(subparsers):
@@ -48,56 +44,4 @@ def main(args):
     if not archive_file.is_file():
         raise ArchiveFileInvalid()
 
-    try:
-        archive_version_index = None
-        staging_path = ctx.output_path / ARCHIVE_STAGING
-        staging_path.mkdir(exist_ok=True)
-        extract_archive(archive_file, staging_path)
-
-        archive_version_index_path = staging_path / ARCHIVE_VERSION_INDEX
-        if not archive_version_index_path.is_file():
-            raise ArchiveFileInvalid().add_extra_context(
-                "Could not locate the archive version index."
-            )
-
-        archive_version_index = VersionIndex.create_or_load(archive_version_index_path)
-        try:
-            archive_version_index.copy_entries_to(
-                dest=ctx.version_index, tasks=None, latest_only=False
-            )
-        except sqlite3.IntegrityError as ex:
-            raise DuplicateTaskOutput(output_dir=str(ctx.output_path)) from ex
-
-        # Copy over all archived task outputs
-        for task_id, version in archive_version_index.get_all_versions():
-            src_task_path = pathlib.Path(
-                staging_path, task_id.path, f.task_output_dir(task_id, version)
-            )
-            if not src_task_path.is_dir():
-                raise ArchiveFileInvalid().add_extra_context(
-                    "Missing archived task output for '{}' at version {} in the "
-                    "archive.".format(str(task_id), str(version))
-                )
-
-            dest_task_path = pathlib.Path(
-                ctx.output_path, task_id.path, f.task_output_dir(task_id, version)
-            )
-            dest_task_path.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copytree(src_task_path, dest_task_path)
-            if not dest_task_path.is_dir():
-                raise ArchiveFileInvalid().add_extra_context(
-                    "Missing copied archived task output for '{}' at version {}.".format(
-                        str(task_id), str(version)
-                    )
-                )
-
-        # Everything was copied over and verified - safe to commit the index changes
-        ctx.version_index.commit_changes()
-
-    except:
-        ctx.version_index.rollback_changes()
-        raise
-
-    finally:
-        del archive_version_index
-        shutil.rmtree(staging_path, ignore_errors=True)
+    restore_archive(ctx, archive_file)

--- a/src/conductor/config.py
+++ b/src/conductor/config.py
@@ -42,7 +42,7 @@ TASK_NAME_ENV_VARIABLE_NAME = "COND_NAME"
 SLOT_ENV_VARIABLE_NAME = "COND_SLOT"
 
 # A template for the default name of a Conductor archive.
-ARCHIVE_FILE_NAME_TEMPLATE = "cond-archive+{timestamp}.tar.gz"
+ARCHIVE_FILE_NAME_TEMPLATE = "cond-archive+{timestamp}.tar.zst"
 
 # The file name of the version index used in a Conductor archive.
 ARCHIVE_VERSION_INDEX = "version_index_archive.sqlite"

--- a/src/conductor/config.py
+++ b/src/conductor/config.py
@@ -42,7 +42,7 @@ TASK_NAME_ENV_VARIABLE_NAME = "COND_NAME"
 SLOT_ENV_VARIABLE_NAME = "COND_SLOT"
 
 # A template for the default name of a Conductor archive.
-ARCHIVE_FILE_NAME_TEMPLATE = "cond-archive+{timestamp}.tar.zst"
+ARCHIVE_FILE_NAME_TEMPLATE = "cond-archive+{timestamp}.tar.{extension}"
 
 # The file name of the version index used in a Conductor archive.
 ARCHIVE_VERSION_INDEX = "version_index_archive.sqlite"

--- a/src/conductor/envs/maestro/daemon.py
+++ b/src/conductor/envs/maestro/daemon.py
@@ -148,6 +148,8 @@ class Maestro(MaestroInterface):
         )
         executor = Executor(execution_slots=1, silent=True)
         executor.run_plan(plan, ctx)
+        # Make sure any new versions are committed.
+        ctx.version_index.commit_changes()
 
         end_timestamp = int(time.time())
         return ExecuteTaskResponse(

--- a/src/conductor/errors/generated.py
+++ b/src/conductor/errors/generated.py
@@ -554,6 +554,20 @@ class DuplicateTaskOutput(ConductorError):
         )
 
 
+class UnsupportedArchiveType(ConductorError):
+    error_code = 4007
+
+    def __init__(self, **kwargs):
+        super().__init__()
+        self.kwargs = kwargs
+        self.archive_type = kwargs["archive_type"]
+
+    def _message(self):
+        return "The provided archive file was compressed as {archive_type}, which is not supported on your platform.".format(
+            archive_type=self.archive_type,
+        )
+
+
 class ConfigParseError(ConductorError):
     error_code = 5001
 
@@ -775,6 +789,7 @@ ERRORS_BY_CODE = {
     4004: CreateArchiveFailed,
     4005: ArchiveFileInvalid,
     4006: DuplicateTaskOutput,
+    4007: UnsupportedArchiveType,
     5001: ConfigParseError,
     5002: ConfigInvalidValue,
     5003: UnsupportedPlatform,
@@ -830,6 +845,7 @@ __all__ = [
     "CreateArchiveFailed",
     "ArchiveFileInvalid",
     "DuplicateTaskOutput",
+    "UnsupportedArchiveType",
     "ConfigParseError",
     "ConfigInvalidValue",
     "UnsupportedPlatform",

--- a/src/conductor/execution/version_index.py
+++ b/src/conductor/execution/version_index.py
@@ -195,6 +195,22 @@ class VersionIndex:
             insert_count += dest.bulk_load(cursor)
         return insert_count
 
+    @staticmethod
+    def copy_specific_entries_to(
+        dest: "VersionIndex", entries: List[Tuple[TaskIdentifier, Version]]
+    ) -> int:
+        values = []
+        for task_id, version in entries:
+            values.append(
+                (
+                    str(task_id),
+                    version.timestamp,
+                    version.commit_hash,
+                    version.has_uncommitted_changes,
+                )
+            )
+        return dest.bulk_load(values)
+
     def bulk_load(self, rows: Iterable) -> int:
         """
         Load the rows into the index and return the number loaded

--- a/src/conductor/execution/version_index_queries.py
+++ b/src/conductor/execution/version_index_queries.py
@@ -33,6 +33,16 @@ insert_new_version = """
   VALUES (?, ?, ?, ?)
 """
 
+insert_new_version_unchecked = """
+  INSERT OR IGNORE INTO version_index (
+    task_identifier,
+    timestamp,
+    git_commit_hash,
+    has_uncommitted_changes
+  )
+  VALUES (?, ?, ?, ?)
+"""
+
 latest_task_version = """
   SELECT
     timestamp,

--- a/src/conductor/execution/version_index_queries.py
+++ b/src/conductor/execution/version_index_queries.py
@@ -8,6 +8,15 @@ create_table = """
   )
 """
 
+# Used when archiving non-versioned task outputs (usually for transport to/from
+# a remote environment).
+create_unversioned_table = """
+  CREATE TABLE IF NOT EXISTS unversioned (
+    task_identifier TEXT NOT NULL,
+    PRIMARY KEY (task_identifier)
+  )
+"""
+
 set_format_version = "PRAGMA user_version = {version:d}"
 
 get_format_version = "PRAGMA user_version"
@@ -99,6 +108,14 @@ all_versions = """
     has_uncommitted_changes
   FROM
     version_index
+"""
+
+add_unversioned_task = """
+  INSERT INTO unversioned (task_identifier) VALUES (?)
+"""
+
+get_unversioned_tasks = """
+  SELECT task_identifier FROM unversioned
 """
 
 

--- a/src/conductor/filename.py
+++ b/src/conductor/filename.py
@@ -1,12 +1,17 @@
-from typing import Optional
+from typing import Optional, TYPE_CHECKING
 
 from conductor.config import ARCHIVE_FILE_NAME_TEMPLATE, TASK_OUTPUT_DIR_SUFFIX
 from conductor.execution.version_index import Version
 from conductor.task_identifier import TaskIdentifier
 
+if TYPE_CHECKING:
+    from conductor.utils.output_archiving import ArchiveType
 
-def archive(timestamp: str) -> str:
-    return ARCHIVE_FILE_NAME_TEMPLATE.format(timestamp=timestamp)
+
+def archive(timestamp: str, archive_type: "ArchiveType") -> str:
+    return ARCHIVE_FILE_NAME_TEMPLATE.format(
+        timestamp=timestamp, extension=archive_type.extension()
+    )
 
 
 def task_output_dir(

--- a/src/conductor/utils/output_archiving.py
+++ b/src/conductor/utils/output_archiving.py
@@ -52,6 +52,7 @@ def create_archive(
             ctx.output_path / ARCHIVE_VERSION_INDEX
         )
         VersionIndex.copy_specific_entries_to(archive_index, versioned_tasks)
+        archive_index.bulk_load_unversioned(unversioned_tasks)
         archive_index.commit_changes()
 
         # Collect the output directories for the tasks to archive.
@@ -76,7 +77,7 @@ def create_archive(
                 "tar",
                 "-cf",
                 str(output_archive_path),
-                "--use-compress-program=zstdmt",
+                f"--use-compress-program={_compress_program(output_archive_path)}",
                 "-C",  # Files to put in the archive are relative to `ctx.output_path`
                 str(ctx.output_path),
                 str(archive_index_path.relative_to(ctx.output_path)),
@@ -119,11 +120,55 @@ def restore_archive(ctx: Context, archive_path: pathlib.Path) -> None:
         except sqlite3.IntegrityError as ex:
             raise DuplicateTaskOutput(output_dir=str(ctx.output_path)) from ex
 
-        # Copy over all archived task outputs.
-        # NOTE: We should copy task by task.
-        shutil.copytree(staging_path, ctx.output_path, dirs_exist_ok=True)
+        # Copy over versioned tasks.
+        for task_id, version in archive_version_index.get_all_versions():
+            src_task_path = pathlib.Path(
+                staging_path, task_id.path, f.task_output_dir(task_id, version)
+            )
+            if not src_task_path.is_dir():
+                raise ArchiveFileInvalid().add_extra_context(
+                    "Missing archived task output for '{}' at version {} in the "
+                    "archive.".format(str(task_id), str(version))
+                )
+
+            dest_task_path = pathlib.Path(
+                ctx.output_path, task_id.path, f.task_output_dir(task_id, version)
+            )
+            dest_task_path.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copytree(src_task_path, dest_task_path)
+            if not dest_task_path.is_dir():
+                raise ArchiveFileInvalid().add_extra_context(
+                    "Missing copied archived task output for '{}' at version {}.".format(
+                        str(task_id), str(version)
+                    )
+                )
+
+        # Copy over unversioned tasks.
+        for task_id in archive_version_index.get_all_unversioned():
+            src_task_path = pathlib.Path(
+                staging_path, task_id.path, f.task_output_dir(task_id)
+            )
+            if not src_task_path.is_dir():
+                raise ArchiveFileInvalid().add_extra_context(
+                    "Missing archived task output for '{}' in the "
+                    "archive.".format(str(task_id))
+                )
+
+            dest_task_path = pathlib.Path(
+                ctx.output_path, task_id.path, f.task_output_dir(task_id)
+            )
+            dest_task_path.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copytree(src_task_path, dest_task_path)
+            if not dest_task_path.is_dir():
+                raise ArchiveFileInvalid().add_extra_context(
+                    "Missing copied archived task output for '{}'.".format(str(task_id))
+                )
+
+        # Safe to commit now.
+        ctx.version_index.commit_changes()
 
     except:
+        # Something went wrong, so undo our changes.
         ctx.version_index.rollback_changes()
         raise
 
@@ -139,7 +184,7 @@ def _extract_archive(archive_file: pathlib.Path, staging_path: pathlib.Path):
                 "tar",
                 "-xf",
                 str(archive_file),
-                "--use-compress-program=zstdmt",
+                f"--use-compress-program={_compress_program(archive_file)}",
                 "-C",
                 str(staging_path),
             ],
@@ -153,3 +198,13 @@ def _extract_archive(archive_file: pathlib.Path, staging_path: pathlib.Path):
 
     except OSError as ex:
         raise ArchiveFileInvalid().add_extra_context(str(ex))
+
+
+def _compress_program(archive_file: pathlib.Path) -> str:
+    if archive_file.suffix == ".gz":
+        # This is a heuristic we use to support legacy Conductor archives (which
+        # were gzip-compressed).
+        return "gzip"
+    else:
+        # Conductor has switched to using zstd for compression.
+        return "zstdmt"

--- a/src/conductor/utils/output_archiving.py
+++ b/src/conductor/utils/output_archiving.py
@@ -269,6 +269,6 @@ def _supports_compress_program(archive_type: ArchiveType) -> bool:
     if archive_type == ArchiveType.Zstd:
         return system == "Linux"
     elif archive_type == ArchiveType.Gzip:
-        return system == "Darwin"
+        return system == "Linux" or system == "Darwin"
     else:
         return False

--- a/src/conductor/utils/output_archiving.py
+++ b/src/conductor/utils/output_archiving.py
@@ -67,9 +67,9 @@ def create_archive(
         process = subprocess.Popen(
             [
                 "tar",
-                "cf",
-                "--use-compress-program=zstdmt",
+                "-cf",
                 str(output_archive_path),
+                "--use-compress-program=zstdmt",
                 "-C",  # Files to put in the archive are relative to `ctx.output_path`
                 str(ctx.output_path),
                 str(archive_index_path.relative_to(ctx.output_path)),

--- a/src/conductor/utils/output_transfer.py
+++ b/src/conductor/utils/output_transfer.py
@@ -1,0 +1,88 @@
+import pathlib
+import subprocess
+from typing import List, Optional, Tuple
+
+import conductor.filename as f
+from conductor.config import ARCHIVE_VERSION_INDEX
+from conductor.context import Context
+from conductor.errors import InternalError, CreateArchiveFailed
+from conductor.execution.version_index import VersionIndex, Version
+from conductor.task_identifier import TaskIdentifier
+
+
+def create_archive(
+    ctx: Context,
+    tasks_to_archive: List[Tuple[TaskIdentifier, Optional[Version]]],
+    output_archive_path: pathlib.Path,
+) -> None:
+    """
+    This utility is used to create an archive of the output directories of the
+    given tasks for transport purposes (e.g., moving data to/from a remote
+    environment).
+    """
+
+    # Ensure versions are specified when they should be specified.
+    # Partition tasks into versioned and unversioned tasks.
+    versioned_tasks = []
+    unversioned_tasks = []
+    for task_id, version in tasks_to_archive:
+        task = ctx.task_index.get_task(task_id)
+        if task.archivable:
+            if version is None:
+                raise InternalError(
+                    details=f"Did not provide a version for an archivable task {str(task_id)}."
+                )
+            versioned_tasks.append((task_id, version))
+        else:
+            unversioned_tasks.append(task_id)
+
+    try:
+        archive_index_path = ctx.output_path / ARCHIVE_VERSION_INDEX
+        archive_index_path.unlink(missing_ok=True)
+
+        # Store the versions of the tasks that are being archived.
+        archive_index = VersionIndex.create_or_load(
+            ctx.output_path / ARCHIVE_VERSION_INDEX
+        )
+        VersionIndex.copy_specific_entries_to(archive_index, versioned_tasks)
+        archive_index.commit_changes()
+
+        # Collect the output directories for the tasks to archive.
+        output_dirs_str = []
+        for task_id, version in versioned_tasks:
+            output_dirs_str.append(
+                str(
+                    pathlib.Path(
+                        task_id.path,
+                        f.task_output_dir(task_id, version),
+                    )
+                )
+            )
+        for task_id in unversioned_tasks:
+            output_dirs_str.append(
+                str(pathlib.Path(task_id.path, f.task_output_dir(task_id)))
+            )
+
+        # Create the archive.
+        process = subprocess.Popen(
+            [
+                "tar",
+                "cf",
+                "--use-compress-program=zstdmt",
+                str(output_archive_path),
+                "-C",  # Files to put in the archive are relative to `ctx.output_path`
+                str(ctx.output_path),
+                str(archive_index_path.relative_to(ctx.output_path)),
+                *output_dirs_str,
+            ],
+            shell=False,
+        )
+        process.wait()
+        if process.returncode != 0:
+            raise CreateArchiveFailed().add_extra_context(
+                "The tar utility returned a non-zero error code."
+            )
+
+    finally:
+        # Clean up the archive index file.
+        archive_index_path.unlink(missing_ok=True)

--- a/tests/cond_archive_restore_test.py
+++ b/tests/cond_archive_restore_test.py
@@ -2,6 +2,7 @@ import pathlib
 import shutil
 
 from .conductor_runner import ConductorRunner, count_task_outputs, EXAMPLE_TEMPLATES
+from conductor.utils.output_archiving import platform_archive_type
 
 
 def test_archive_restore(tmp_path: pathlib.Path):
@@ -16,12 +17,14 @@ def test_archive_restore(tmp_path: pathlib.Path):
     result = cond.archive("//figures:graph", output_path=None, latest=False)
     assert result.returncode == 0
 
+    expected_archive_type = platform_archive_type()
+
     # Make sure we found the archive
     found_archive = False
     archive_name = None
     orig_archive_path = None
     for file in cond.output_path.iterdir():
-        if file.name.endswith(".tar.zst"):
+        if file.name.endswith(f".tar.{expected_archive_type.extension()}"):
             found_archive = True
             archive_name = file.name
             orig_archive_path = file
@@ -32,12 +35,12 @@ def test_archive_restore(tmp_path: pathlib.Path):
 
     # Restoring the archive into an output directory that already contains the results
     # should fail
-    result = cond.restore(orig_archive_path)
+    result = cond.restore(orig_archive_path, strict=True)
     assert result.returncode != 0
 
     # Remove the output directory and then try restoring
     shutil.rmtree(cond.output_path)
-    result = cond.restore(cond.project_root / archive_name)
+    result = cond.restore(cond.project_root / archive_name, strict=True)
     assert result.returncode == 0
 
     # Only the run_experiment() task output should be restored
@@ -48,7 +51,7 @@ def test_archive_restore(tmp_path: pathlib.Path):
 
 def test_restore_invalid(tmp_path: pathlib.Path):
     cond = ConductorRunner.from_template(tmp_path, EXAMPLE_TEMPLATES["hello_world"])
-    result = cond.restore(cond.output_path / "non_existent.tar.zst")
+    result = cond.restore(cond.output_path / "non_existent.tar.zst", strict=True)
     assert result.returncode != 0
 
 
@@ -57,7 +60,9 @@ def test_archive_output(tmp_path: pathlib.Path):
     result = cond.run("//:hello_world")
     assert result.returncode == 0
 
-    output_archive = cond.project_root / "custom.tar.zst"
+    expected_archive_type = platform_archive_type()
+    expected_extension = expected_archive_type.extension()
+    output_archive = cond.project_root / f"custom.tar.{expected_extension}"
     assert not output_archive.exists()
     result = cond.archive("//:hello_world", output_path=output_archive, latest=False)
     assert result.returncode == 0
@@ -73,11 +78,16 @@ def test_archive_output_dir(tmp_path: pathlib.Path):
     result = cond.archive("//:hello_world", output_path=cond.project_root, latest=False)
     assert result.returncode == 0
 
+    expected_archive_type = platform_archive_type()
+    expected_extension = expected_archive_type.extension()
+
     # Ensure the archive was saved in the correct output directory with a
     # Conductor-provided name
     archive_found = False
     for file in cond.project_root.iterdir():
-        if file.name.startswith("cond-archive") and file.name.endswith(".tar.zst"):
+        if file.name.startswith("cond-archive") and file.name.endswith(
+            f".tar.{expected_extension}"
+        ):
             archive_found = True
             break
     assert archive_found
@@ -108,20 +118,23 @@ def test_archive_restore_latest(tmp_path: pathlib.Path):
     assert result.returncode == 0
     assert count_task_outputs(cond.output_path) == 2
 
+    expected_archive_type = platform_archive_type()
+    expected_extension = expected_archive_type.extension()
+
     # Archive the latest only
-    output_archive = cond.project_root / "latest.tar.zst"
+    output_archive = cond.project_root / f"latest.tar.{expected_extension}"
     assert not output_archive.exists()
     result = cond.archive("//:hello_world", output_path=output_archive, latest=True)
     assert result.returncode == 0
     assert output_archive.exists() and output_archive.is_file()
 
     # Restoring into an existing experiment output directory should fail
-    result = cond.restore(output_archive)
+    result = cond.restore(output_archive, strict=True)
     assert result.returncode != 0
 
     # Restore into an empty output path. Only one of the experiment outputs
     # should have been archived (and thus restored).
     shutil.rmtree(cond.output_path)
-    result = cond.restore(output_archive)
+    result = cond.restore(output_archive, strict=True)
     assert result.returncode == 0
     assert count_task_outputs(cond.output_path) == 1

--- a/tests/cond_archive_restore_test.py
+++ b/tests/cond_archive_restore_test.py
@@ -21,7 +21,7 @@ def test_archive_restore(tmp_path: pathlib.Path):
     archive_name = None
     orig_archive_path = None
     for file in cond.output_path.iterdir():
-        if file.name.endswith(".tar.gz"):
+        if file.name.endswith(".tar.zst"):
             found_archive = True
             archive_name = file.name
             orig_archive_path = file
@@ -48,7 +48,7 @@ def test_archive_restore(tmp_path: pathlib.Path):
 
 def test_restore_invalid(tmp_path: pathlib.Path):
     cond = ConductorRunner.from_template(tmp_path, EXAMPLE_TEMPLATES["hello_world"])
-    result = cond.restore(cond.output_path / "non_existent.tar.gz")
+    result = cond.restore(cond.output_path / "non_existent.tar.zst")
     assert result.returncode != 0
 
 
@@ -57,7 +57,7 @@ def test_archive_output(tmp_path: pathlib.Path):
     result = cond.run("//:hello_world")
     assert result.returncode == 0
 
-    output_archive = cond.project_root / "custom.tar.gz"
+    output_archive = cond.project_root / "custom.tar.zst"
     assert not output_archive.exists()
     result = cond.archive("//:hello_world", output_path=output_archive, latest=False)
     assert result.returncode == 0
@@ -77,7 +77,7 @@ def test_archive_output_dir(tmp_path: pathlib.Path):
     # Conductor-provided name
     archive_found = False
     for file in cond.project_root.iterdir():
-        if file.name.startswith("cond-archive") and file.name.endswith(".tar.gz"):
+        if file.name.startswith("cond-archive") and file.name.endswith(".tar.zst"):
             archive_found = True
             break
     assert archive_found
@@ -109,7 +109,7 @@ def test_archive_restore_latest(tmp_path: pathlib.Path):
     assert count_task_outputs(cond.output_path) == 2
 
     # Archive the latest only
-    output_archive = cond.project_root / "latest.tar.gz"
+    output_archive = cond.project_root / "latest.tar.zst"
     assert not output_archive.exists()
     result = cond.archive("//:hello_world", output_path=output_archive, latest=True)
     assert result.returncode == 0

--- a/tests/conductor_runner.py
+++ b/tests/conductor_runner.py
@@ -88,8 +88,13 @@ class ConductorRunner:
             cmd.append("--latest")
         return self._run_command(cmd)
 
-    def restore(self, archive_path: pathlib.Path) -> subprocess.CompletedProcess:
-        return self._run_command(["restore", str(archive_path)])
+    def restore(
+        self, archive_path: pathlib.Path, strict: bool
+    ) -> subprocess.CompletedProcess:
+        cmd = ["restore", str(archive_path)]
+        if strict:
+            cmd.append("--strict")
+        return self._run_command(cmd)
 
     def gc(
         self, dry_run: bool = False, verbose: bool = False

--- a/tests/general_archiving_test.py
+++ b/tests/general_archiving_test.py
@@ -3,7 +3,11 @@ from conductor.config import VERSION_INDEX_NAME
 from conductor.context import Context
 from conductor.execution.version_index import VersionIndex
 from conductor.task_identifier import TaskIdentifier
-from conductor.utils.output_archiving import create_archive, restore_archive
+from conductor.utils.output_archiving import (
+    create_archive,
+    restore_archive,
+    ArchiveType,
+)
 from .conductor_runner import ConductorRunner, EXAMPLE_TEMPLATES
 
 
@@ -26,7 +30,7 @@ def test_overall_archiving(tmp_path: pathlib.Path):
     ]
     archive_output_path = cond.project_root / "test_archive.tar.gz"
     assert not archive_output_path.exists()
-    create_archive(ctx, to_archive, archive_output_path)
+    create_archive(ctx, to_archive, archive_output_path, archive_type=ArchiveType.Gzip)
     assert archive_output_path.exists()
 
     # Clear the output directory and recreate the Context to clear out cached
@@ -36,7 +40,7 @@ def test_overall_archiving(tmp_path: pathlib.Path):
     assert result.returncode == 0
 
     # Restore the archive.
-    restore_archive(ctx, archive_output_path)
+    restore_archive(ctx, archive_output_path, archive_type=ArchiveType.Gzip)
 
     # Check that the output directories for the relevant tasks were restored.
     expt_out_dir = cond.find_task_output_dir(str(run_benchmark_id), is_experiment=True)

--- a/tests/general_archiving_test.py
+++ b/tests/general_archiving_test.py
@@ -1,0 +1,32 @@
+import pathlib
+from conductor.config import VERSION_INDEX_NAME
+from conductor.context import Context
+from conductor.execution.version_index import VersionIndex
+from conductor.task_identifier import TaskIdentifier
+from conductor.utils.output_archiving import create_archive
+from .conductor_runner import ConductorRunner, EXAMPLE_TEMPLATES
+
+
+def test_overall_archiving(tmp_path: pathlib.Path):
+    cond = ConductorRunner.from_template(tmp_path, EXAMPLE_TEMPLATES["dependencies"])
+    result = cond.run("//figures:graph")
+    assert result.returncode == 0
+
+    run_benchmark_id = TaskIdentifier.from_str("//experiments:run_benchmark")
+    figures_id = TaskIdentifier.from_str("//figures:graph")
+    version_index = VersionIndex.create_or_load(cond.output_path / VERSION_INDEX_NAME)
+    versions = version_index.get_all_versions_for_task(run_benchmark_id)
+    assert len(versions) == 1
+
+    ctx = Context(cond.project_root)
+    ctx.task_index.load_transitive_closure(figures_id)
+    to_archive = [
+        (run_benchmark_id, versions[0]),
+        (figures_id, None),
+    ]
+    archive_output_path = cond.output_path / "test_archive.tar.gz"
+    assert not archive_output_path.exists()
+    create_archive(ctx, to_archive, archive_output_path)
+    assert archive_output_path.exists()
+
+    # TODO: Try to restore the archive and check that the output is correct.

--- a/website/docs/cli/restore.md
+++ b/website/docs/cli/restore.md
@@ -19,6 +19,13 @@ for more details about Conductor's archive and restore features.
 
 The path to the archive file to restore.
 
+### `--strict`
+
+By default, Conductor will only restore result versions that do not exist in
+your local results directory. If this flag is set, Conductor will abort the
+restore if any result versions in the archive already exist in your local
+results directory.
+
 ## Optional Arguments
 
 ### `-h` or `--help`


### PR DESCRIPTION
This adds generic task result archival/restore utilities that will be used for results transfer to/from an environment. This also refactors the existing archive/restore tools to use these new utilities.

This PR also:
- Resolves #82 
- Resolves #106 (we switch to `zstdmt` by default on Linux platforms)